### PR TITLE
Fix: Change TypeScript types from interface to function exports

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,4 @@
-export interface ChineseWorkday{
-  isWorkday(day: string | Date): boolean;
-  isHoliday(day: string | Date): boolean;
-  getFestival(day: string | Date): string;
-}
+export function isWorkday(day: string | Date): boolean;
+export function isHoliday(day: string | Date): boolean;
+export function getFestival(day: string | Date): string;
+export function isAddtionalWorkday(day: string | Date): boolean;


### PR DESCRIPTION
## Summary
Fix TypeScript type definitions to export functions directly instead of an interface, matching the actual module exports.

## Changes
- Changed `index.d.ts` from interface export to function exports
- Added missing `isAddtionalWorkday` type definition

## Fixes
- Closes #4

## Testing
- All existing unit tests pass
- TypeScript compilation verified